### PR TITLE
Fix build warning regarding Node 16

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
The v3 of the github actions use Node 16 which is deprecated:
> Node.js 16 actions are deprecated. Please update the following actions
> to use Node.js 20: actions/checkout@v3.